### PR TITLE
avoid fancy math in docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,22 @@
 Package: burnout
 Title: Compute Probability of Epidemic Burnout
 Version: 0.0.1
-Authors@R: 
-    person("David", "Earn", , "earn@math.mcmaster.ca", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0002-7562-1341"))
+Authors@R: c(person("David", "Earn",
+  email = "earn@math.mcmaster.ca",
+  comment = c(ORCID = "0000-0002-7562-1341"),
+  role = c("aut", "cre")),
+  person("Ben", "Bolker",
+  role = c("aut"),
+  comment=c(ORCID="0000-0002-2127-0443"))
+  )
 Description: Compute the probability that an infectious disease -- modelled
-    using the standard Susceptible-Infectious-Recovered (SIR) model -- 
+    using the standard Susceptible-Infectious-Recovered (SIR) model --
     persists beyond an initial outbreak.
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
-Imports: 
+Imports:
     Rdpack,
     emdbook,
     expint,
@@ -21,5 +26,5 @@ Imports:
     rlang,
     deSolve
 RdMacros: Rdpack
-Suggests: 
+Suggests:
     testthat, sirr

--- a/R/P1.R
+++ b/R/P1.R
@@ -12,7 +12,7 @@
 ##' where \eqn{q} is Kendall's \eqn{q}, the expected total population
 ##' size is \eqn{N}, and the equilibrium prevalence is
 ##' 
-##' \deqn{y^\star = \varepsilon\Big(1 - \dfrac{1}{{\cal R}_0}\Big) \,.}
+##' \deqn{y^\star = \varepsilon\Big(1 - \frac{1}{{\cal R}_0}\Big) \,.}
 ##' 
 ##' Hence, the probability of \emph{either} fizzling before a first
 ##' major outbreak \emph{or} burning out after a first major outbreak
@@ -27,7 +27,7 @@
 ##' first epidemic is
 ##' 
 ##' \deqn{
-##'     {{\mathscr P}_1}({\cal R}_0,\varepsilon,k,N) =
+##'     {{\cal P}_1}({\cal R}_0,\varepsilon,k,N) =
 ##'       p_k\big( 1 - q^{Ny^\star} \big) \,.
 ##' }
 ##'
@@ -134,7 +134,7 @@ burnout_prob_hocb <- function(R0, epsilon, N=10^6,
 
 ##' Persistence probability via other approximations
 ##'
-##' This computes \eqn{{\mathscr P}_1} using the burnout probability
+##' This computes \eqn{{\cal P}_1} using the burnout probability
 ##' approximations of van Herwaarden (1997) or Meerson and Sasorov
 ##' (2009).
 ##'

--- a/R/burnout.R
+++ b/R/burnout.R
@@ -9,7 +9,7 @@
 ##' The primary functions are \code{\link{P1_prob}},
 ##'     \code{\link{fizzle_prob}}, \code{\link{fizzle_time}}, and
 ##'     \code{\link{t_herd}}.  There are also functions to compare
-##'     approximations of \eqn{{\mathscr P}_1} and component
+##'     approximations of \eqn{{\cal P}_1} and component
 ##'     calculations.
 ##'
 ##' @docType package

--- a/R/compare.R
+++ b/R/compare.R
@@ -33,7 +33,7 @@
 compare_funs <- function(fun1 = q_exact, fun2 = q_approx,
                          R0 = NULL, Rmin = 1.001, Rmax = 64, nR0 = 101,
                          epsilon = 10^(-(4:1)), nepsilon = length(epsilon),
-                         N = 10^6,
+                         N = NULL,
                          ...,
                          show.progress=FALSE) {
 
@@ -70,10 +70,18 @@ compare_funs <- function(fun1 = q_exact, fun2 = q_approx,
         r <- raw[i,"R0"]
         e <- raw[i,"epsilon"]
         if (show.progress) cat(sprintf("%d\t%g\t%g", i, r, e))
-        f1i <- try(fun1(R0=r, epsilon=e, N=N, ...))
+        if (is.null(N)) {
+            f1i <- try(fun1(R0=r, epsilon=e, ...))
+        } else {
+            f1i <- try(fun1(R0=r, epsilon=e, N=N, ...))
+        }
         if ("try-error" %in% class(f1i)) f1i <- NA
         if (show.progress) cat(sprintf("\t%g", f1i))
-        f2i <- try(fun2(R0=r, epsilon=e, N=N, ...))
+        if (is.null(N)) {
+            f2i <- try(fun2(R0=r, epsilon=e, ...))
+        } else {
+            f2i <- try(fun2(R0=r, epsilon=e, N=N, ...))
+        }
         if ("try-error" %in% class(f2i)) f2i <- NA
         if (show.progress) cat(sprintf("\t%g\n", f2i))
         f1[i] <- f1i

--- a/R/fizzle.R
+++ b/R/fizzle.R
@@ -6,10 +6,12 @@
 ##' The fizzle probability is
 ##' 
 ##' \deqn{1 - p_k =
-##'   \begin{cases}
+##'   \left\{
+##'   \begin{array}{rl}
 ##'      1\,, & 0 \le {\cal R}_0 \le 1, \\
-##'      \left(\dfrac{1}{{\cal R}_0}\right)^{k} \,, & 1\le{\cal R}_0.
-##'   \end{cases}
+##'      \left(\frac{1}{{\cal R}_0}\right)^{k} \,, & 1\le{\cal R}_0.
+##'   \end{array}
+##'   \right.
 ##' }
 ##'
 ##' @param R0 basic reproduction number (\eqn{{\cal R}_0})
@@ -38,10 +40,12 @@ fizzle_prob <- function(R0, k=1) {
 ##' The probability of not fizzling is
 ##' 
 ##' \deqn{p_k =
-##'   \begin{cases}
+##'   \left\{
+##'   \begin{array}{rl}
 ##'      0\,, & 0 \le {\cal R}_0 \le 1, \\
-##'      1 - \left(\dfrac{1}{{\cal R}_0}\right)^{k} \,, & 1\le{\cal R}_0.
-##'   \end{cases}
+##'      1 - \left(\frac{1}{{\cal R}_0}\right)^{k} \,, & 1\le{\cal R}_0.
+##'   \end{array}
+##'   \right.
 ##' }
 ##'
 ##' @seealso \code{\link{fizzle_prob}}
@@ -67,7 +71,7 @@ not_fizzle_prob <- function(R0, k=1) {
 ##' \eqn{t_\delta} is \eqn{< \delta}
 ##'
 ##' \deqn{
-##' 	t_{\delta} =  \dfrac{1}{{\cal R}_{0}-1} \ln\left(\dfrac{(1-\delta)^{-\frac{1}{k}}-\frac{1}{{\cal R}_{0}}}{(1-\delta)^{-\frac{1}{k}}-1}\right).
+##' 	t_{\delta} =  \frac{1}{{\cal R}_{0}-1} \ln\left(\frac{(1-\delta)^{-\frac{1}{k}}-\frac{1}{{\cal R}_{0}}}{(1-\delta)^{-\frac{1}{k}}-1}\right).
 ##' }
 ##'
 ##' @inheritParams P1_prob

--- a/R/llig.R
+++ b/R/llig.R
@@ -18,13 +18,13 @@
 ##' \emph{normalized} area under the curve \eqn{t^{a-1}e^{-t}} ([NIST
 ##' 8.2.4](https://dlmf.nist.gov/8.2#E4)) is
 ##' 
-##' \deqn{P(a,x) = \dfrac{\texttt{lig}(a,x)}{\Gamma(a)} .}
+##' \deqn{P(a,x) = \frac{\texttt{lig}(a,x)}{\Gamma(a)} .}
 ##' 
 ##' This is the cumulative distribution of the Gamma distribution
 ##' (\code{\link[stats]{pgamma}}), which we can calculate and express
 ##' on the log scale via
 ##' 
-##' \deqn{\fcolorbox{red}{aqua}{\code{pgamma(shape=a, q=x, lower.tail = TRUE, log.p = TRUE)}}}
+##' \deqn{\fcolorbox{red}{blue}{\code{pgamma(shape=a, q=x, lower.tail = TRUE, log.p = TRUE)}}}
 ##' 
 ##' Since \eqn{\log(\Gamma(a))} can be calculated directly on the
 ##' log scale via \code{\link[base]{lgamma}}, we can do the entire

--- a/R/peak_prev.R
+++ b/R/peak_prev.R
@@ -6,10 +6,10 @@
 ##'
 ##' \deqn{
 ##'   y_{\rm max} \approx 1-
-##'     \dfrac{1}{{\cal R}_{0}}\big(1 +\ln{{\cal R}_{0}}\big)
+##'     \frac{1}{{\cal R}_{0}}\big(1 +\ln{{\cal R}_{0}}\big)
 ##'     - \varepsilon 
-##'   \Big(1-\dfrac{1}{{\cal R}_0}\Big)
-##'   \dfrac{(\ln{{\cal R}_0})\big/\big(1-\frac{1}{{\cal R}_0}\big) - 1}
+##'   \Big(1-\frac{1}{{\cal R}_0}\Big)
+##'   \frac{(\ln{{\cal R}_0})\big/\big(1-\frac{1}{{\cal R}_0}\big) - 1}
 ##'   {(\ln{{\cal R}_0})\big/\big(1-\frac{1}{{\cal R}_0}\big) + {\cal R}_0} \,.
 ##' }
 ##'
@@ -44,7 +44,7 @@ peak_prev <- function( R0, epsilon=0 ) {
 ##'
 ##' \deqn{
 ##'   y_{\rm max} = 1 -
-##'     \dfrac{1}{{\cal R}_{0}}\big(1 +\ln{{\cal R}_{0}}\big) \,.
+##'     \frac{1}{{\cal R}_{0}}\big(1 +\ln{{\cal R}_{0}}\big) \,.
 ##' }
 ##' 
 ##' The optional argument (\code{epsilon}) is ignored if given.  The

--- a/R/plot.R
+++ b/R/plot.R
@@ -104,7 +104,8 @@ plot.compare_funs <- function(x, show.plots=TRUE, ...) {
 
     ## make title
     N <- attr(x,"N")
-    title.text <- sprintf("$N = 10^{%d}$", log10(N))
+    title.text <- if (is.null(N)) "" else sprintf("$N = 10^{%d}$",
+                                                  log10(N))
 
     ## scatter plot coloured by epsilon:
     scatter.plot <- (x %>% ggplot()

--- a/R/plot.R
+++ b/R/plot.R
@@ -3,7 +3,7 @@
 ##' @inheritParams P1_prob
 ##' @param Rmin,Rmax minimum and maximum value of \eqn{{\cal R}_0}
 ##' @param show.N,show.epsilon if \code{TRUE}, display parameter value in legend
-##' @param P1_fun function that computes \eqn{{\mathscr P}_1}
+##' @param P1_fun function that computes \eqn{{\cal P}_1}
 ##' @param add if \code{TRUE}, add to existing plot
 ##' @param col,lwd,log standard \link{graphical parameters}
 ##' @param ... additional parameters passed to \code{\link{plot}}

--- a/R/q.R
+++ b/R/q.R
@@ -19,8 +19,6 @@
 ##'
 ##' @inheritParams peak_prev
 ##' @param xin by default set via the approximation coded in \code{\link{x_in}}
-##' @param N population size (ignored, but present so this function
-##'     can be passed to \code{\link{compare_funs}})
 ##'
 ##' @return real number between 0 and 1
 ##' @importFrom Rdpack reprompt
@@ -39,7 +37,7 @@
 ##' curve(q_exact(x,epsilon=0.01), from=1.01, to=2, las=1, add=TRUE, col="magenta", n=1001)
 ##' curve(q_exact(x,epsilon=0.1), from=1.01, to=2, las=1, add=TRUE, col="cyan", n=1001)
 ##'
-q_exact <- function(R0, epsilon, xin = x_in(R0,epsilon), N=NULL) {
+q_exact <- function(R0, epsilon, xin = x_in(R0,epsilon)) {
     a <- (R0/epsilon)*(1-1/R0)
     x <- (R0/epsilon)*(1-xin)
     ##denom <- exp(x) * x^(-a) * lig(a,x)
@@ -88,7 +86,7 @@ q_exact <- function(R0, epsilon, xin = x_in(R0,epsilon), N=NULL) {
 ##' curve(q_approx(x,epsilon=0.01), from=1.01, to=2, las=1, add=TRUE, col="magenta", n=1001)
 ##' curve(q_approx(x,epsilon=0.1), from=1.01, to=2, las=1, add=TRUE, col="cyan", n=1001)
 ##'
-q_approx <- function(R0, epsilon, xin = x_in(R0,epsilon), N=NULL) {
+q_approx <- function(R0, epsilon, xin = x_in(R0,epsilon)) {
     a <- (R0/epsilon)*(1 - 1/R0)
     b <- (R0/epsilon)*(1/R0 - xin)
     log.fac1 <- (1/2)*(log(2*pi) - log(epsilon*(R0-1)))

--- a/R/q.R
+++ b/R/q.R
@@ -8,7 +8,7 @@
 ##' 
 ##' \deqn{
 ##' 	q({\cal R}_0,\varepsilon,x_{\rm in}) =
-##' \left(1+\dfrac{\varepsilon}{e^{\frac{{\cal R}_{0}}{\varepsilon} (1-x_{\rm in})}
+##' \left(1+\frac{\varepsilon}{e^{\frac{{\cal R}_{0}}{\varepsilon} (1-x_{\rm in})}
 ##' \left(\frac{{\cal R}_{0}}{\varepsilon}
 ##' (1-x_{\rm in})\right)^{-\frac{{\cal R}_{0}}{\varepsilon}\left(1-\frac{1}{{\cal R}_{0}}\right)}
 ##' {\cal g}\left(\frac{{\cal R}_{0}}{\varepsilon}\left(1-\frac{1}{{\cal R}_{0}}\right),\frac{{\cal R}_{0}}{\varepsilon}(1-x_{\rm in})\right)}\right)^{-1}.
@@ -61,7 +61,7 @@ q_exact <- function(R0, epsilon, xin = x_in(R0,epsilon), N=NULL) {
 ##' \deqn{
 ##' q({\cal R}_0,\varepsilon,x_{\rm in}) \approx
 ##' \left(1 +
-##' \dfrac{1}{1+\sqrt{\frac{2\pi}{\varepsilon ({\cal R}_{0}-1)}} \;e^{\frac{{\cal R}_{0}}{\varepsilon}\big(\frac{1}{{\cal R}_{0}}-x_{\rm in}\big)}
+##' \frac{1}{1+\sqrt{\frac{2\pi}{\varepsilon ({\cal R}_{0}-1)}} \;e^{\frac{{\cal R}_{0}}{\varepsilon}\big(\frac{1}{{\cal R}_{0}}-x_{\rm in}\big)}
 ##' \Big(\frac{1-\frac{1}{{\cal R}_{0}}}{1-x_{\rm in}}\Big)^{\frac{{\cal R}_{0}}{\varepsilon}\big(1-\frac{1}{{\cal R}_{0}}\big)}}
 ##' \right)^{-1}\,.
 ##' }

--- a/R/t_herd.R
+++ b/R/t_herd.R
@@ -7,8 +7,8 @@
 ##' proportion susceptible next rises above the threshold.
 ##'
 ##' \deqn{
-##' 	t_{\rm H} =  \dfrac{1}{\varepsilon}
-##'     \ln\Big( \dfrac{1-x_{\rm in}}{1 - \frac{1}{{\cal R}_0}} \Big)
+##' 	t_{\rm H} =  \frac{1}{\varepsilon}
+##'     \ln\Big( \frac{1-x_{\rm in}}{1 - \frac{1}{{\cal R}_0}} \Big)
 ##' }
 ##'
 ##' @inheritParams P1_prob

--- a/R/x_in.R
+++ b/R/x_in.R
@@ -4,7 +4,7 @@
 ##' the boundary layer at the end of the first epidemic.
 ##'
 ##' \deqn{
-##' 	x_{\rm in} = -\dfrac{1}{{\cal R}_{0}} W_{0}\left(-{\cal R}_{0} e^{-{\cal R}_{0}\left(1-y^{\star}\right)}\right) + \varepsilon\, e^{{\cal R}_{0} y^{\star}}\big(E_{1}({\cal R}_{0} y^{\star}) - E_{1}({\cal R}_{0} y_{\rm max}) \big) \,.
+##' 	x_{\rm in} = -\frac{1}{{\cal R}_{0}} W_{0}\left(-{\cal R}_{0} e^{-{\cal R}_{0}\left(1-y^{\star}\right)}\right) + \varepsilon\, e^{{\cal R}_{0} y^{\star}}\big(E_{1}({\cal R}_{0} y^{\star}) - E_{1}({\cal R}_{0} y_{\rm max}) \big) \,.
 ##' }
 ##'
 ##' Here, \eqn{W_{0}} denotes the principal branch of the Lambert
@@ -105,7 +105,7 @@ x_in_crude <- function(R0, epsilon, peakprev_fun = NULL, maxiter=100, ...) {
 ##'
 ##' @details
 ##' \deqn{
-##' 	x_{\rm in} = 1 + \left(1-\frac{1}{{\mathcal R}_{0}}\right) W_{-1}\left(-\dfrac{1-x_{\rm f}}{1-\frac{1}{{\mathcal R}_{0}}} e^{-\frac{1-x_{\rm f}}{1-\frac{1}{{\mathcal R}_{0}}}}\left(\dfrac{y_{\rm max}}{y^*}\right)^{\frac{\varepsilon}{{\mathcal R}_{0}}\frac{1}{1-\frac{1}{{\mathcal R}_{0}}}}\right)
+##' 	x_{\rm in} = 1 + \left(1-\frac{1}{{\mathcal R}_{0}}\right) W_{-1}\left(-\frac{1-x_{\rm f}}{1-\frac{1}{{\mathcal R}_{0}}} e^{-\frac{1-x_{\rm f}}{1-\frac{1}{{\mathcal R}_{0}}}}\left(\frac{y_{\rm max}}{y^*}\right)^{\frac{\varepsilon}{{\mathcal R}_{0}}\frac{1}{1-\frac{1}{{\mathcal R}_{0}}}}\right)
 ##' }
 ##'
 ##' @inheritParams x_in

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 
 The `burnout` package requires R ≥ 4.2.0 in order for the documentation to be displayed as desired.  As mentioned [here](https://cran.r-project.org/doc/manuals/r-devel/NEWS.html), 4.2.0 automatically supports [KaTeX](https://katex.org/docs/support_table.html) and [MathJax](https://www.mathjax.org/), which I use liberally in [roxygen](https://roxygen2.r-lib.org/) documentation.
 
-- The `sirr` package (only suggested: needed for some auxiliary tests) is in a private repository (`https://github.com/davidean/sirr`).  If desired, clone it and install from a local directory, or use `remotes::install_github` with the `auth_token=` argument.
-- LaTeX issues: mathscr (mathrsfs package?, 
-   Debugging: R CMD Rdconv man/burnout.Rd
+- LaTeX issues: `\\mathscr` (`mathrsfs` package?, 
+   Debugging: `R CMD Rdconv man/burnout.Rd`
    
 ```
 R CMD Rd2pdf burnout/man/burnout.Rd
@@ -46,11 +45,14 @@ In the above plot (with `Rmax = 20`) the bottom two panels (for
 
 To compare the approximate and exact `xin`, use
 ```
+cxine <- compare_funs(x_in, x_in_exact)
+plot(cxine)
+```
+or, to look a little more closely use, for example,
+```
 cxine <- compare_funs(x_in, x_in_exact, Rmax=8, epsilon=0.01)
 plot(cxine)
 ```
-(Note that this is slow because the numerical integration is slow.
-Also note that larger `Rmax` causes `lsoda` to crash.)
 
 To compare van Herwaarden's (1997) approximation to ours:
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 
 The `burnout` package requires R ≥ 4.2.0 in order for the documentation to be displayed as desired.  As mentioned [here](https://cran.r-project.org/doc/manuals/r-devel/NEWS.html), 4.2.0 automatically supports [KaTeX](https://katex.org/docs/support_table.html) and [MathJax](https://www.mathjax.org/), which I use liberally in [roxygen](https://roxygen2.r-lib.org/) documentation.
 
-The `sirr` package (only suggested: needed for some auxiliary tests) is in a private repository (`https://github.com/davidean/sirr`).  If desired, clone it and install from a local directory, or use `remotes::install_github` with the `auth_token=` argument.
+- The `sirr` package (only suggested: needed for some auxiliary tests) is in a private repository (`https://github.com/davidean/sirr`).  If desired, clone it and install from a local directory, or use `remotes::install_github` with the `auth_token=` argument.
+- LaTeX issues: mathscr (mathrsfs package?, 
+   Debugging: R CMD Rdconv man/burnout.Rd
+   
+```
+R CMD Rd2pdf burnout/man/burnout.Rd
+```
 
 # generating graphs from Parsons _et al_ (2022)
 

--- a/man/P1_prob.Rd
+++ b/man/P1_prob.Rd
@@ -45,7 +45,7 @@ conditional on not fizzling is
 where \eqn{q} is Kendall's \eqn{q}, the expected total population
 size is \eqn{N}, and the equilibrium prevalence is
 
-\deqn{y^\star = \varepsilon\Big(1 - \dfrac{1}{{\cal R}_0}\Big) \,.}
+\deqn{y^\star = \varepsilon\Big(1 - \frac{1}{{\cal R}_0}\Big) \,.}
 
 Hence, the probability of \emph{either} fizzling before a first
 major outbreak \emph{or} burning out after a first major outbreak
@@ -60,7 +60,7 @@ Consequently, the probability of \emph{persisting} beyond the
 first epidemic is
 
 \deqn{
-    {{\mathscr P}_1}({\cal R}_0,\varepsilon,k,N) =
+    {{\cal P}_1}({\cal R}_0,\varepsilon,k,N) =
       p_k\big( 1 - q^{Ny^\star} \big) \,.
 }
 }

--- a/man/P1_prob_other.Rd
+++ b/man/P1_prob_other.Rd
@@ -35,7 +35,7 @@ probability (either \code{\link{burnout_prob_vanH}} or
 \code{\link[stats]{integrate}}}
 }
 \description{
-This computes \eqn{{\mathscr P}_1} using the burnout probability
+This computes \eqn{{\cal P}_1} using the burnout probability
 approximations of van Herwaarden (1997) or Meerson and Sasorov
 (2009).
 }

--- a/man/burnout.Rd
+++ b/man/burnout.Rd
@@ -15,7 +15,7 @@ model.
 The primary functions are \code{\link{P1_prob}},
 \code{\link{fizzle_prob}}, \code{\link{fizzle_time}}, and
 \code{\link{t_herd}}.  There are also functions to compare
-approximations of \eqn{{\mathscr P}_1} and component
+approximations of \eqn{{\cal P}_1} and component
 calculations.
 }
 

--- a/man/compare_funs.Rd
+++ b/man/compare_funs.Rd
@@ -13,7 +13,7 @@ compare_funs(
   nR0 = 101,
   epsilon = 10^(-(4:1)),
   nepsilon = length(epsilon),
-  N = 10^6,
+  N = NULL,
   ...,
   show.progress = FALSE
 )

--- a/man/fizzle_prob.Rd
+++ b/man/fizzle_prob.Rd
@@ -22,10 +22,12 @@ substantial outbreak.
 The fizzle probability is
 
 \deqn{1 - p_k =
-  \begin{cases}
+  \left\{
+  \begin{array}{rl}
      1\,, & 0 \le {\cal R}_0 \le 1, \\
-     \left(\dfrac{1}{{\cal R}_0}\right)^{k} \,, & 1\le{\cal R}_0.
-  \end{cases}
+     \left(\frac{1}{{\cal R}_0}\right)^{k} \,, & 1\le{\cal R}_0.
+  \end{array}
+  \right.
 }
 }
 \examples{

--- a/man/fizzle_time.Rd
+++ b/man/fizzle_time.Rd
@@ -19,7 +19,7 @@ Time \eqn{t_\delta} for which probability of fizzle after
 }
 \details{
 \deqn{
-	t_{\delta} =  \dfrac{1}{{\cal R}_{0}-1} \ln\left(\dfrac{(1-\delta)^{-\frac{1}{k}}-\frac{1}{{\cal R}_{0}}}{(1-\delta)^{-\frac{1}{k}}-1}\right).
+	t_{\delta} =  \frac{1}{{\cal R}_{0}-1} \ln\left(\frac{(1-\delta)^{-\frac{1}{k}}-\frac{1}{{\cal R}_{0}}}{(1-\delta)^{-\frac{1}{k}}-1}\right).
 }
 }
 \examples{

--- a/man/llig.Rd
+++ b/man/llig.Rd
@@ -33,13 +33,13 @@ for the recovery rate in the SIR model.
 Since \eqn{\Gamma(a) = \texttt{lig}(a,\infty)}, the
 \emph{normalized} area under the curve \eqn{t^{a-1}e^{-t}} (\href{https://dlmf.nist.gov/8.2#E4}{NIST 8.2.4}) is
 
-\deqn{P(a,x) = \dfrac{\texttt{lig}(a,x)}{\Gamma(a)} .}
+\deqn{P(a,x) = \frac{\texttt{lig}(a,x)}{\Gamma(a)} .}
 
 This is the cumulative distribution of the Gamma distribution
 (\code{\link[stats]{pgamma}}), which we can calculate and express
 on the log scale via
 
-\deqn{\fcolorbox{red}{aqua}{\code{pgamma(shape=a, q=x, lower.tail = TRUE, log.p = TRUE)}}}
+\deqn{\fcolorbox{red}{blue}{\code{pgamma(shape=a, q=x, lower.tail = TRUE, log.p = TRUE)}}}
 
 Since \eqn{\log(\Gamma(a))} can be calculated directly on the
 log scale via \code{\link[base]{lgamma}}, we can do the entire

--- a/man/not_fizzle_prob.Rd
+++ b/man/not_fizzle_prob.Rd
@@ -22,10 +22,12 @@ causing a substantial outbreak.
 The probability of not fizzling is
 
 \deqn{p_k =
-  \begin{cases}
+  \left\{
+  \begin{array}{rl}
      0\,, & 0 \le {\cal R}_0 \le 1, \\
-     1 - \left(\dfrac{1}{{\cal R}_0}\right)^{k} \,, & 1\le{\cal R}_0.
-  \end{cases}
+     1 - \left(\frac{1}{{\cal R}_0}\right)^{k} \,, & 1\le{\cal R}_0.
+  \end{array}
+  \right.
 }
 }
 \examples{

--- a/man/peak_prev.Rd
+++ b/man/peak_prev.Rd
@@ -24,10 +24,10 @@ The peak prevalence is
 
 \deqn{
   y_{\rm max} \approx 1-
-    \dfrac{1}{{\cal R}_{0}}\big(1 +\ln{{\cal R}_{0}}\big)
+    \frac{1}{{\cal R}_{0}}\big(1 +\ln{{\cal R}_{0}}\big)
     - \varepsilon 
-  \Big(1-\dfrac{1}{{\cal R}_0}\Big)
-  \dfrac{(\ln{{\cal R}_0})\big/\big(1-\frac{1}{{\cal R}_0}\big) - 1}
+  \Big(1-\frac{1}{{\cal R}_0}\Big)
+  \frac{(\ln{{\cal R}_0})\big/\big(1-\frac{1}{{\cal R}_0}\big) - 1}
   {(\ln{{\cal R}_0})\big/\big(1-\frac{1}{{\cal R}_0}\big) + {\cal R}_0} \,.
 }
 

--- a/man/peak_prev_nvd.Rd
+++ b/man/peak_prev_nvd.Rd
@@ -22,7 +22,7 @@ Exact peak prevalence in the SIR model with \emph{no vital dynamics} (nvd).
 \details{
 \deqn{
   y_{\rm max} = 1 -
-    \dfrac{1}{{\cal R}_{0}}\big(1 +\ln{{\cal R}_{0}}\big) \,.
+    \frac{1}{{\cal R}_{0}}\big(1 +\ln{{\cal R}_{0}}\big) \,.
 }
 
 The optional argument (\code{epsilon}) is ignored if given.  The

--- a/man/plot_P1.Rd
+++ b/man/plot_P1.Rd
@@ -28,7 +28,7 @@ lifetime, i.e., no mortality)}
 
 \item{Rmin, Rmax}{minimum and maximum value of \eqn{{\cal R}_0}}
 
-\item{P1_fun}{function that computes \eqn{{\mathscr P}_1}}
+\item{P1_fun}{function that computes \eqn{{\cal P}_1}}
 
 \item{add}{if \code{TRUE}, add to existing plot}
 

--- a/man/q_approx.Rd
+++ b/man/q_approx.Rd
@@ -32,7 +32,7 @@ obtain
 \deqn{
 q({\cal R}_0,\varepsilon,x_{\rm in}) \approx
 \left(1 +
-\dfrac{1}{1+\sqrt{\frac{2\pi}{\varepsilon ({\cal R}_{0}-1)}} \;e^{\frac{{\cal R}_{0}}{\varepsilon}\big(\frac{1}{{\cal R}_{0}}-x_{\rm in}\big)}
+\frac{1}{1+\sqrt{\frac{2\pi}{\varepsilon ({\cal R}_{0}-1)}} \;e^{\frac{{\cal R}_{0}}{\varepsilon}\big(\frac{1}{{\cal R}_{0}}-x_{\rm in}\big)}
 \Big(\frac{1-\frac{1}{{\cal R}_{0}}}{1-x_{\rm in}}\Big)^{\frac{{\cal R}_{0}}{\varepsilon}\big(1-\frac{1}{{\cal R}_{0}}\big)}}
 \right)^{-1}\,.
 }

--- a/man/q_approx.Rd
+++ b/man/q_approx.Rd
@@ -4,7 +4,7 @@
 \alias{q_approx}
 \title{Kendall's \eqn{q} (Laplace approximation)}
 \usage{
-q_approx(R0, epsilon, xin = x_in(R0, epsilon), N = NULL)
+q_approx(R0, epsilon, xin = x_in(R0, epsilon))
 }
 \arguments{
 \item{R0}{basic reproduction number (\eqn{{\cal R}_0})}
@@ -14,9 +14,6 @@ lifetime (\eqn{1/\mu}; \eqn{\varepsilon = 0} corresponds to infinite
 lifetime, i.e., no mortality)}
 
 \item{xin}{by default set via the approximation coded in \code{\link{x_in}}}
-
-\item{N}{population size (ignored, but present so this function
-can be passed to \code{\link{compare_funs}})}
 }
 \value{
 real number between 0 and 1

--- a/man/q_exact.Rd
+++ b/man/q_exact.Rd
@@ -31,7 +31,7 @@ to the stochastic SIR model with one infected individual yields
 
 \deqn{
 	q({\cal R}_0,\varepsilon,x_{\rm in}) =
-\left(1+\dfrac{\varepsilon}{e^{\frac{{\cal R}_{0}}{\varepsilon} (1-x_{\rm in})}
+\left(1+\frac{\varepsilon}{e^{\frac{{\cal R}_{0}}{\varepsilon} (1-x_{\rm in})}
 \left(\frac{{\cal R}_{0}}{\varepsilon}
 (1-x_{\rm in})\right)^{-\frac{{\cal R}_{0}}{\varepsilon}\left(1-\frac{1}{{\cal R}_{0}}\right)}
 {\cal g}\left(\frac{{\cal R}_{0}}{\varepsilon}\left(1-\frac{1}{{\cal R}_{0}}\right),\frac{{\cal R}_{0}}{\varepsilon}(1-x_{\rm in})\right)}\right)^{-1}.

--- a/man/q_exact.Rd
+++ b/man/q_exact.Rd
@@ -4,7 +4,7 @@
 \alias{q_exact}
 \title{Kendall's \eqn{q} (exact expression)}
 \usage{
-q_exact(R0, epsilon, xin = x_in(R0, epsilon), N = NULL)
+q_exact(R0, epsilon, xin = x_in(R0, epsilon))
 }
 \arguments{
 \item{R0}{basic reproduction number (\eqn{{\cal R}_0})}
@@ -14,9 +14,6 @@ lifetime (\eqn{1/\mu}; \eqn{\varepsilon = 0} corresponds to infinite
 lifetime, i.e., no mortality)}
 
 \item{xin}{by default set via the approximation coded in \code{\link{x_in}}}
-
-\item{N}{population size (ignored, but present so this function
-can be passed to \code{\link{compare_funs}})}
 }
 \value{
 real number between 0 and 1

--- a/man/t_herd.Rd
+++ b/man/t_herd.Rd
@@ -23,8 +23,8 @@ proportion susceptible next rises above the threshold.
 }
 \details{
 \deqn{
-	t_{\rm H} =  \dfrac{1}{\varepsilon}
-    \ln\Big( \dfrac{1-x_{\rm in}}{1 - \frac{1}{{\cal R}_0}} \Big)
+	t_{\rm H} =  \frac{1}{\varepsilon}
+    \ln\Big( \frac{1-x_{\rm in}}{1 - \frac{1}{{\cal R}_0}} \Big)
 }
 }
 \examples{

--- a/man/x_in.Rd
+++ b/man/x_in.Rd
@@ -30,7 +30,7 @@ the boundary layer at the end of the first epidemic.
 }
 \details{
 \deqn{
-	x_{\rm in} = -\dfrac{1}{{\cal R}_{0}} W_{0}\left(-{\cal R}_{0} e^{-{\cal R}_{0}\left(1-y^{\star}\right)}\right) + \varepsilon\, e^{{\cal R}_{0} y^{\star}}\big(E_{1}({\cal R}_{0} y^{\star}) - E_{1}({\cal R}_{0} y_{\rm max}) \big) \,.
+	x_{\rm in} = -\frac{1}{{\cal R}_{0}} W_{0}\left(-{\cal R}_{0} e^{-{\cal R}_{0}\left(1-y^{\star}\right)}\right) + \varepsilon\, e^{{\cal R}_{0} y^{\star}}\big(E_{1}({\cal R}_{0} y^{\star}) - E_{1}({\cal R}_{0} y_{\rm max}) \big) \,.
 }
 
 Here, \eqn{W_{0}} denotes the principal branch of the Lambert

--- a/man/x_in_cb.Rd
+++ b/man/x_in_cb.Rd
@@ -26,7 +26,7 @@ Susceptibles at boundary layer (corner/boundary layer approximation)
 }
 \details{
 \deqn{
-	x_{\rm in} = 1 + \left(1-\frac{1}{{\mathcal R}_{0}}\right) W_{-1}\left(-\dfrac{1-x_{\rm f}}{1-\frac{1}{{\mathcal R}_{0}}} e^{-\frac{1-x_{\rm f}}{1-\frac{1}{{\mathcal R}_{0}}}}\left(\dfrac{y_{\rm max}}{y^*}\right)^{\frac{\varepsilon}{{\mathcal R}_{0}}\frac{1}{1-\frac{1}{{\mathcal R}_{0}}}}\right)
+	x_{\rm in} = 1 + \left(1-\frac{1}{{\mathcal R}_{0}}\right) W_{-1}\left(-\frac{1-x_{\rm f}}{1-\frac{1}{{\mathcal R}_{0}}} e^{-\frac{1-x_{\rm f}}{1-\frac{1}{{\mathcal R}_{0}}}}\left(\frac{y_{\rm max}}{y^*}\right)^{\frac{\varepsilon}{{\mathcal R}_{0}}\frac{1}{1-\frac{1}{{\mathcal R}_{0}}}}\right)
 }
 }
 \seealso{


### PR DESCRIPTION
This simplifies some LaTeX markup (`dfrac → frac`, `mathscr → cal`, colour `aqua → blue`,  `cases → \left\{ \array{} ... \right .` to allow the PDF versions of the manual to get built.

See https://stat.ethz.ch/pipermail/r-package-devel/2022q3/008391.html for more explanation.
